### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Build Status](https://travis-ci.org/causes/overcommit.svg)](https://travis-ci.org/causes/overcommit)
 [![Code Climate](https://codeclimate.com/github/causes/overcommit.png)](https://codeclimate.com/github/causes/overcommit)
 [![Dependency Status](https://gemnasium.com/causes/overcommit.svg)](https://gemnasium.com/causes/overcommit)
+[![Inline docs](http://inch-ci.org/github/causes/overcommit.svg?branch=master)](http://inch-ci.org/github/causes/overcommit)
 
 # Overcommit
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/causes/overcommit.svg)](http://inch-ci.org/github/causes/overcommit)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/causes/overcommit/

What do you think?