### PR TITLE
Add standard and semistandard pre-commit hooks

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -234,6 +234,13 @@ PreCommit:
     flags: ['--format=gcc']
     include: '**/*.sh'
 
+  Standard:
+    description: 'Analyzing with standard'
+    required_executable: 'standard'
+    flags: ['--verbose']
+    install_command: 'npm install -g standard'
+    include: '**/*.js'
+
   TrailingWhitespace:
     description: 'Checking for trailing whitespace'
     required_executable: 'grep'

--- a/config/default.yml
+++ b/config/default.yml
@@ -222,6 +222,14 @@ PreCommit:
       - '**/Gemfile'
       - '**/Rakefile'
 
+  SemiStandard:
+    enabled: false
+    description: 'Analyzing with semistandard'
+    required_executable: 'semistandard'
+    flags: ['--verbose']
+    install_command: 'npm install -g semistandard'
+    include: '**/*.js'
+
   ScssLint:
     description: 'Analyzing with scss-lint'
     required_executable: 'scss-lint'

--- a/lib/overcommit/hook/pre_commit/semi_standard.rb
+++ b/lib/overcommit/hook/pre_commit/semi_standard.rb
@@ -1,0 +1,17 @@
+module Overcommit::Hook::PreCommit
+  # Runs `semistandard` against any modified JavaScript files.
+  class SemiStandard < Base
+    def run
+      result = execute(command + applicable_files)
+      output = result.stderr.chomp
+      return :pass if result.success? && output.empty?
+
+      # example message:
+      #   path/to/file.js:1:1: Error message (ruleName)
+      extract_messages(
+        output.split("\n")[1..-1], # ignore header line
+        /^(?<file>[^:]+):(?<line>\d+)/
+      )
+    end
+  end
+end

--- a/lib/overcommit/hook/pre_commit/standard.rb
+++ b/lib/overcommit/hook/pre_commit/standard.rb
@@ -1,0 +1,17 @@
+module Overcommit::Hook::PreCommit
+  # Runs `standard` against any modified JavaScript files.
+  class Standard < Base
+    def run
+      result = execute(command + applicable_files)
+      output = result.stderr.chomp
+      return :pass if result.success? && output.empty?
+
+      # example message:
+      #   path/to/file.js:1:1: Error message (ruleName)
+      extract_messages(
+        output.split("\n")[1..-1], # ignore header line
+        /^(?<file>[^:]+):(?<line>\d+)/
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::SemiStandard do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.js file2.js])
+  end
+
+  context 'when semistandard exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success? => true, :stderr => '')
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when semistandard exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stderr).and_return([
+          'Error: Code style check failed:',
+          'file1.js:1:1: Extra semicolon. (eslint/semi)'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([1, 2])
+      end
+
+      it { should fail_hook }
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/standard_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Standard do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.js file2.js])
+  end
+
+  context 'when standard exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success? => true, :stderr => '')
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when standard exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stderr).and_return([
+          'Error: Use JavaScript Standard Style (https://github.com/feross/standard)',
+          'file1.js:1:1: Extra semicolon. (eslint/semi)'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([1, 2])
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Add pre-commit hooks for [standard](https://github.com/feross/standard) and [semistandard](https://github.com/Flet/semistandard) JavaScript linters.