### PR TITLE
Add pre-commit hooks for w3c_validators

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -294,6 +294,7 @@ PreCommit:
       - '**/*.css'
 
   W3cHtmlValidator:
+    enabled: false
     description: 'Analyzing with W3C HTML validation service'
     validator_uri: 'http://validator.w3.org/check'
     charset: 'utf-8'

--- a/config/default.yml
+++ b/config/default.yml
@@ -283,6 +283,24 @@ PreCommit:
     description: 'Checking YAML syntax'
     include: '**/*.yml'
 
+  W3cCssValidator:
+    enabled: false
+    description: 'Analyzing with W3C CSS validation service'
+    validator_uri: 'http://jigsaw.w3.org/css-validator/validator'
+    language: 'en'
+    profile: 'css3'
+    warn_level: 2
+    include:
+      - '**/*.css'
+
+  W3cHtmlValidator:
+    description: 'Analyzing with W3C HTML validation service'
+    validator_uri: 'http://validator.w3.org/check'
+    charset: 'utf-8'
+    doctype: 'HTML5'
+    include:
+      - '**/*.html'
+
 # Hooks that run after HEAD changes or a file is explicitly checked out.
 PostCheckout:
   ALL:

--- a/lib/overcommit/hook/pre_commit/w3c_css_validator.rb
+++ b/lib/overcommit/hook/pre_commit/w3c_css_validator.rb
@@ -1,0 +1,74 @@
+module Overcommit::Hook::PreCommit
+  # Runs `w3c_validators` against any modified CSS files.
+  class W3cCssValidator < Base
+    def run
+      begin
+        require 'w3c_validators'
+      rescue LoadError
+        return :warn, 'w3c_validators not installed -- run `gem install w3c_validators`'
+      end
+
+      result_messages =
+        begin
+          applicable_files.collect do |path|
+            results = validator.validate_file(path)
+            messages = results.errors + results.warnings
+            messages.collect do |msg|
+              # Some warnings are not per-line, so use 0 as a default
+              line = Integer(msg.line || 0)
+
+              # Build message by hand to reduce noise from the validator response
+              text = "#{msg.type.to_s.upcase}; URI: #{path}; line #{line}: #{msg.message.strip}"
+              Overcommit::Hook::Message.new(msg.type, path, line, text)
+            end
+          end
+        rescue W3CValidators::ValidatorUnavailable => e
+          return :fail, e.message
+        rescue W3CValidators::ParsingError => e
+          return :fail, e.message
+        end
+
+      result_messages.flatten!
+      return :pass if result_messages.empty?
+
+      result_messages
+    end
+
+    private
+
+    def validator
+      unless @validator
+        @validator = W3CValidators::CSSValidator.new(opts)
+        @validator.set_language!(language) unless language.nil?
+        @validator.set_profile!(profile) unless profile.nil?
+        @validator.set_warn_level!(warn_level) unless warn_level.nil?
+      end
+      @validator
+    end
+
+    def opts
+      @opts ||= {
+        validator_uri: config['validator_uri'],
+        proxy_server:  config['proxy_server'],
+        proxy_port:    config['proxy_port'],
+        proxy_user:    config['proxy_user'],
+        proxy_pass:    config['proxy_pass']
+      }
+    end
+
+    def language
+      @language ||= config['language']
+    end
+
+    # Values specified at
+    #   http://www.rubydoc.info/gems/w3c_validators/1.2/W3CValidators#CSS_PROFILES
+    def profile
+      @profile ||= config['profile']
+    end
+
+    # One of 0, 1, 2, 'no'
+    def warn_level
+      @warn_level ||= config['warn_level']
+    end
+  end
+end

--- a/lib/overcommit/hook/pre_commit/w3c_css_validator.rb
+++ b/lib/overcommit/hook/pre_commit/w3c_css_validator.rb
@@ -5,7 +5,7 @@ module Overcommit::Hook::PreCommit
       begin
         require 'w3c_validators'
       rescue LoadError
-        return :warn, 'w3c_validators not installed -- run `gem install w3c_validators`'
+        return :fail, 'w3c_validators not installed -- run `gem install w3c_validators`'
       end
 
       result_messages =

--- a/lib/overcommit/hook/pre_commit/w3c_html_validator.rb
+++ b/lib/overcommit/hook/pre_commit/w3c_html_validator.rb
@@ -5,7 +5,7 @@ module Overcommit::Hook::PreCommit
       begin
         require 'w3c_validators'
       rescue LoadError
-        return :warn, 'w3c_validators not installed -- run `gem install w3c_validators`'
+        return :fail, 'w3c_validators not installed -- run `gem install w3c_validators`'
       end
 
       result_messages =

--- a/lib/overcommit/hook/pre_commit/w3c_html_validator.rb
+++ b/lib/overcommit/hook/pre_commit/w3c_html_validator.rb
@@ -1,0 +1,71 @@
+module Overcommit::Hook::PreCommit
+  # Runs `w3c_validators` against any modified HTML files.
+  class W3cHtmlValidator < Base
+    def run
+      begin
+        require 'w3c_validators'
+      rescue LoadError
+        return :warn, 'w3c_validators not installed -- run `gem install w3c_validators`'
+      end
+
+      result_messages =
+        begin
+          applicable_files.collect do |path|
+            results = validator.validate_file(path)
+            messages = results.errors + results.warnings
+            messages.collect do |msg|
+              # Some warnings are not per-line, so use 0 as a default
+              line = Integer(msg.line || 0)
+
+              # Build message by hand to reduce noise from the validator response
+              text = "#{msg.type.to_s.upcase}; URI: #{path}; line #{line}: #{msg.message.strip}"
+              Overcommit::Hook::Message.new(msg.type, path, line, text)
+            end
+          end
+        rescue W3CValidators::ValidatorUnavailable => e
+          return :fail, e.message
+        rescue W3CValidators::ParsingError => e
+          return :fail, e.message
+        end
+
+      result_messages.flatten!
+      return :pass if result_messages.empty?
+
+      result_messages
+    end
+
+    private
+
+    def validator
+      unless @validator
+        @validator = W3CValidators::MarkupValidator.new(opts)
+        @validator.set_charset!(charset, only_as_fallback = true) unless charset.nil?
+        @validator.set_doctype!(doctype, only_as_fallback = true) unless doctype.nil?
+        @validator.set_debug!
+      end
+      @validator
+    end
+
+    def opts
+      @opts ||= {
+        validator_uri: config['validator_uri'],
+        proxy_server:  config['proxy_server'],
+        proxy_port:    config['proxy_port'],
+        proxy_user:    config['proxy_user'],
+        proxy_pass:    config['proxy_pass']
+      }
+    end
+
+    # Values specified at
+    #   http://www.rubydoc.info/gems/w3c_validators/1.2/W3CValidators#CHARSETS
+    def charset
+      @charset ||= config['charset']
+    end
+
+    # Values specified at
+    #   http://www.rubydoc.info/gems/w3c_validators/1.2/W3CValidators#DOCTYPES
+    def doctype
+      @doctype ||= config['doctype']
+    end
+  end
+end

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency             'childprocess', '~> 0.5.0'
 
+  s.add_development_dependency 'w3c_validators', '~> 1.2'
   s.add_development_dependency 'image_optim', '~> 0.20.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'travis', '~> 1.7'

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency             'childprocess', '~> 0.5.0'
 
-  s.add_development_dependency 'w3c_validators', '~> 1.2'
   s.add_development_dependency 'image_optim', '~> 0.20.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'travis', '~> 1.7'
+  s.add_development_dependency 'w3c_validators', '~> 1.2'
 end

--- a/spec/overcommit/hook/pre_commit/w3c_css_validator_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_css_validator_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+require 'w3c_validators'
+
+describe Overcommit::Hook::PreCommit::W3cCssValidator do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.css file2.css])
+  end
+
+  context 'when w3c_validators exits with an exception' do
+    let(:validator) { double('validator') }
+
+    before do
+      subject.stub(:validator).and_return(validator)
+    end
+
+    context 'when the validator is not available' do
+      before do
+        validator.stub(:validate_file).and_raise(W3CValidators::ValidatorUnavailable)
+      end
+
+      it { should fail_hook }
+    end
+
+    context 'when the validator response cannot be parsed' do
+      before do
+        validator.stub(:validate_file).and_raise(W3CValidators::ParsingError)
+      end
+
+      it { should fail_hook }
+    end
+  end
+
+  context 'when w3c_validators exits without an exception' do
+    let(:validator) { double('validator') }
+    let(:results) { double('results') }
+    let(:message) { double('message') }
+
+    before do
+      validator.stub(:validate_file).and_return(results)
+      subject.stub(:validator).and_return(validator)
+    end
+
+    context 'with no errors or warnings' do
+      before do
+        results.stub(:errors => [], :warnings => [])
+      end
+
+      it { should pass }
+    end
+
+    context 'with a warning' do
+      before do
+        message.stub(:type => :warning, :line => '1', :message => '')
+        results.stub(:errors => [], :warnings => [message])
+        subject.stub(:modified_lines_in_file).and_return([2, 3])
+      end
+
+      it { should warn }
+    end
+
+    context 'with an error' do
+      before do
+        message.stub(:type => :error, :line => '1', :message => '')
+        results.stub(:errors => [message], :warnings => [])
+        subject.stub(:modified_lines_in_file).and_return([1, 2])
+      end
+
+      it { should fail_hook }
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/w3c_html_validator_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_html_validator_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+require 'w3c_validators'
+
+describe Overcommit::Hook::PreCommit::W3cHtmlValidator do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.html file2.html])
+  end
+
+  context 'when w3c_validators exits with an exception' do
+    let(:validator) { double('validator') }
+
+    before do
+      subject.stub(:validator).and_return(validator)
+    end
+
+    context 'when the validator is not available' do
+      before do
+        validator.stub(:validate_file).and_raise(W3CValidators::ValidatorUnavailable)
+      end
+
+      it { should fail_hook }
+    end
+
+    context 'when the validator response cannot be parsed' do
+      before do
+        validator.stub(:validate_file).and_raise(W3CValidators::ParsingError)
+      end
+
+      it { should fail_hook }
+    end
+  end
+
+  context 'when w3c_validators exits without an exception' do
+    let(:validator) { double('validator') }
+    let(:results) { double('results') }
+    let(:message) { double('message') }
+
+    before do
+      validator.stub(:validate_file).and_return(results)
+      subject.stub(:validator).and_return(validator)
+    end
+
+    context 'with no errors or warnings' do
+      before do
+        results.stub(:errors => [], :warnings => [])
+      end
+
+      it { should pass }
+    end
+
+    context 'with a warning' do
+      before do
+        message.stub(:type => :warning, :line => '1', :message => '')
+        results.stub(:errors => [], :warnings => [message])
+        subject.stub(:modified_lines_in_file).and_return([2, 3])
+      end
+
+      it { should warn }
+    end
+
+    context 'with an error' do
+      before do
+        message.stub(:type => :error, :line => '1', :message => '')
+        results.stub(:errors => [message], :warnings => [])
+        subject.stub(:modified_lines_in_file).and_return([1, 2])
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Add pre-commit hooks for W3C's HTML and CSS validation services, accessed through the [w3c_validators](https://github.com/alexdunae/w3c_validators) gem.

`W3cCssValidator` is disabled by default, as the service seems a little finicky with large inputs.