### PR TITLE
Quote `file_path` in `extract_modified_lines`

### DIFF
--- a/lib/overcommit/git_repo.rb
+++ b/lib/overcommit/git_repo.rb
@@ -23,7 +23,7 @@ module Overcommit
       refs = options[:refs]
       subcmd = options[:subcmd] || 'diff'
 
-      `git #{subcmd} --no-ext-diff -U0 #{flags} #{refs} -- #{file_path}`.
+      `git #{subcmd} --no-ext-diff -U0 #{flags} #{refs} -- '#{file_path}'`.
         scan(DIFF_HUNK_REGEX) do |start_line, lines_added|
         lines_added = (lines_added || 1).to_i # When blank, one line was added
         cur_line = start_line.to_i


### PR DESCRIPTION
This fixes a bug where lines modified in files with spaces in their
paths are not recognized.