### PR TITLE
Add pre-commit hook for pep8

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -192,6 +192,13 @@ PreCommit:
     required_executable: 'grep'
     flags: ['-IHn', '^<<<<<<<\s']
 
+  Pep8:
+    enabled: false
+    description: 'Analyzing with pep8'
+    required_executable: 'pep8'
+    install_command: 'pip install pep8'
+    include: '**/*.py'
+
   PryBinding:
     description: 'Checking for instances of binding.pry'
     quiet: true

--- a/lib/overcommit/hook/pre_commit/pep8.rb
+++ b/lib/overcommit/hook/pre_commit/pep8.rb
@@ -1,0 +1,19 @@
+module Overcommit::Hook::PreCommit
+  # Runs `pep8` against any modified Python files.
+  class Pep8 < Base
+    def run
+      result = execute(command + applicable_files)
+      output = result.stdout.chomp
+
+      return :pass if result.success? && output.empty?
+
+      # example message:
+      #   path/to/file.py:88:5: E301 expected 1 blank line, found 0
+      extract_messages(
+        output.split("\n"),
+        /^(?<file>[^:]+):(?<line>\d+):\d+:\s(?<type>E|W)/,
+        lambda { |type| type.include?('W') ? :warning : :error }
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/pep8_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pep8_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Pep8 do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.py file2.py])
+  end
+
+  context 'when pep8 exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success? => true, :stdout => '')
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when pep8 exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports a warning' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.py:1:1: W391 blank line at end of file'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([2, 3])
+      end
+
+      it { should warn }
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.py:1:80: E501 line too long (80 > 79 characters)'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([1, 2])
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Add hook for [pep8](https://pypi.python.org/pypi/pep8), a Python linter. Disable by default, as [flake8](https://pypi.python.org/pypi/flake8) already includes pep8.

This is useful for those who prefer to omit warnings from [pyflakes](https://pypi.python.org/pypi/pyflakes), which is also included in flake8. 