### PR TITLE
Add pre-commit hook for pyflakes

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -199,6 +199,13 @@ PreCommit:
       - '**/*.rb'
       - '**/*.rake'
 
+  Pyflakes:
+    enabled: false
+    description: 'Analyzing with pyflakes'
+    required_executable: 'pyflakes'
+    install_command: 'pip install pyflakes'
+    include: '**/*.py'
+
   PythonFlake8:
     description: 'Analyzing with flake8'
     required_executable: 'flake8'

--- a/lib/overcommit/hook/pre_commit/pyflakes.rb
+++ b/lib/overcommit/hook/pre_commit/pyflakes.rb
@@ -1,0 +1,28 @@
+module Overcommit::Hook::PreCommit
+  # Runs `pyflakes` against any modified Python files.
+  class Pyflakes < Base
+    MESSAGE_REGEX = /^(?<file>[^:]+):(?<line>\d+):/
+
+    def run
+      result = execute(command + applicable_files)
+      return :pass if result.success?
+
+      errors = get_messages(result.stderr, :error)
+      warnings = get_messages(result.stdout, :warning)
+
+      errors + warnings
+    end
+
+    private
+
+    def get_messages(output, type)
+      # example message:
+      #   path/to/file.py:57: local variable 'x' is assigned to but never used
+      extract_messages(
+        output.split("\n").grep(MESSAGE_REGEX),
+        MESSAGE_REGEX,
+        proc { type }
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/pyflakes_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pyflakes_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Pyflakes do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.py file2.py])
+  end
+
+  context 'when pyflakes exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success? => true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when pyflakes exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(success?: false, stdout: '', stderr: '')
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports a warning' do
+      before do
+        result.stub(:stdout).and_return([
+          "file1.py:1: local variable 'x' is assigned to but never used"
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([2, 3])
+      end
+
+      it { should warn }
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stderr).and_return([
+          'file1.py:1:1: invalid syntax'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([1, 2])
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Add hook for [pyflakes](https://pypi.python.org/pypi/pyflakes). Disable by default, as [flake8](https://pypi.python.org/pypi/flake8) includes pyflakes.

This is useful for those who want semantic linting without the style checking of [pep8](https://pypi.python.org/pypi/pep8).