### PR TITLE
Add pre-commit hook for pep257

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -198,6 +198,12 @@ PreCommit:
     required_executable: 'grep'
     flags: ['-IHn', '^<<<<<<<\s']
 
+  Pep257:
+    description: 'Analyzing with pep257'
+    required_executable: 'pep257'
+    install_command: 'pip install pep257'
+    include: '**/*.py'
+
   Pep8:
     enabled: false
     description: 'Analyzing with pep8'

--- a/config/default.yml
+++ b/config/default.yml
@@ -199,7 +199,7 @@ PreCommit:
     flags: ['-IHn', '^<<<<<<<\s']
 
   Pep257:
-    description: 'Analyzing with pep257'
+    description: 'Analyzing docstrings with pep257'
     required_executable: 'pep257'
     install_command: 'pip install pep257'
     include: '**/*.py'

--- a/lib/overcommit/hook/pre_commit/pep257.rb
+++ b/lib/overcommit/hook/pre_commit/pep257.rb
@@ -1,0 +1,19 @@
+module Overcommit::Hook::PreCommit
+  # Runs `pep257` against any modified Python files.
+  class Pep257 < Base
+    def run
+      result = execute(command + applicable_files)
+      return :pass if result.success?
+
+      output = result.stderr.chomp
+
+      # example message:
+      #   path/to/file.py:1 in public method `foo`:
+      #           D102: Docstring missing
+      extract_messages(
+        output.gsub(/:\s+/, ': ').split("\n"),
+        /^(?<file>[^:]+):(?<line>\d+)/
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/pep257_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pep257_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Pep257 do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.py file2.py])
+  end
+
+  context 'when pep257 exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when pep257 exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stderr).and_return([
+          'file1.py:1 in public method `foo`:',
+          '        D102: Docstring missing'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([2, 3])
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Add hook for [pep257](https://pypi.python.org/pypi/pep257), a linter for Python docstrings.