### PR TITLE
Improve message parsing for PythonFlake8

### DIFF
--- a/lib/overcommit/hook/pre_commit/python_flake8.rb
+++ b/lib/overcommit/hook/pre_commit/python_flake8.rb
@@ -1,29 +1,13 @@
 module Overcommit::Hook::PreCommit
   # Runs `flake8` against any modified Python files.
   class PythonFlake8 < Base
-    # The following regex marks these pyflakes and pep8 codes as errors.
-    # All other codes are marked as warnings.
-    #
-    # Pyflake Errors:
-    #  - F402 import module from line N shadowed by loop variable
-    #  - F404 future import(s) name after other statements
-    #  - F812 list comprehension redefines name from line N
-    #  - F823 local variable name ... referenced before assignment
-    #  - F831 duplicate argument name in function definition
-    #  - F821 undefined name name
-    #  - F822 undefined name name in __all__
-    #
-    # Pep8 Errors:
-    #  - E112 expected an indented block
-    #  - E113 unexpected indentation
-    #  - E901 SyntaxError or IndentationError
-    #  - E902 IOError
-    ERROR_REGEX = /F(?:40[24]|8(?:12|2[123]|31))|E(?:11[23]|90[12])/
+    MESSAGE_REGEX = /^(?<file>.+):(?<line>\d+):\d+:\s(?<type>\w\d+)/
 
-    MESSAGE_REGEX = /^(?<file>.+):(?<line>\d+):\d+:\s(?<type>[FEWCN]\d+)/
-
+    # Classify 'Exxx' and 'Fxxx' message codes as errors,
+    # everything else as warnings.
+    #   http://flake8.readthedocs.org/en/latest/warnings.html
     MESSAGE_TYPE_CATEGORIZER = lambda do |type|
-      type =~ ERROR_REGEX ? :error : :warning
+      'EF'.include?(type[0]) ? :error : :warning
     end
 
     def run

--- a/lib/overcommit/hook/pre_commit/python_flake8.rb
+++ b/lib/overcommit/hook/pre_commit/python_flake8.rb
@@ -1,11 +1,44 @@
 module Overcommit::Hook::PreCommit
   # Runs `flake8` against any modified Python files.
   class PythonFlake8 < Base
+    # The following regex marks these pyflakes and pep8 codes as errors.
+    # All other codes are marked as warnings.
+    #
+    # Pyflake Errors:
+    #  - F402 import module from line N shadowed by loop variable
+    #  - F404 future import(s) name after other statements
+    #  - F812 list comprehension redefines name from line N
+    #  - F823 local variable name ... referenced before assignment
+    #  - F831 duplicate argument name in function definition
+    #  - F821 undefined name name
+    #  - F822 undefined name name in __all__
+    #
+    # Pep8 Errors:
+    #  - E112 expected an indented block
+    #  - E113 unexpected indentation
+    #  - E901 SyntaxError or IndentationError
+    #  - E902 IOError
+    ERROR_REGEX = /F(?:40[24]|8(?:12|2[123]|31))|E(?:11[23]|90[12])/
+
+    MESSAGE_REGEX = /^(?<file>.+):(?<line>\d+):\d+:\s(?<type>[FEWCN]\d+)/
+
+    MESSAGE_TYPE_CATEGORIZER = lambda do |type|
+      type =~ ERROR_REGEX ? :error : :warning
+    end
+
     def run
       result = execute(command + applicable_files)
       return :pass if result.success?
 
-      [:fail, result.stdout]
+      output = result.stdout.chomp
+
+      # example message:
+      #   path/to/file.py:2:13: F812 list comprehension redefines name from line 1
+      extract_messages(
+        output.split("\n").grep(MESSAGE_REGEX),
+        MESSAGE_REGEX,
+        MESSAGE_TYPE_CATEGORIZER
+      )
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
+++ b/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
@@ -30,7 +30,7 @@ describe Overcommit::Hook::PreCommit::PythonFlake8 do
     context 'and it reports a warning' do
       before do
         result.stub(:stdout).and_return([
-          'file1.py:1:80: E501 line too long (80 > 79 characters)'
+          'file1.py:1:1: W292 no newline at end of file'
         ].join("\n"))
 
         subject.stub(:modified_lines_in_file).and_return([2, 3])

--- a/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
+++ b/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
@@ -13,21 +13,42 @@ describe Overcommit::Hook::PreCommit::PythonFlake8 do
     before do
       result = double('result')
       result.stub(:success?).and_return(true)
-      result.stub(:stdout)
       subject.stub(:execute).and_return(result)
     end
 
     it { should pass }
   end
 
-  context 'when scss-lint exits unsucessfully' do
+  context 'when flake8 exits unsucessfully' do
+    let(:result) { double('result') }
+
     before do
-      result = double('result')
       result.stub(:success?).and_return(false)
-      result.stub(:stdout)
       subject.stub(:execute).and_return(result)
     end
 
-    it { should fail_hook }
+    context 'and it reports a warning' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.py:1:80: E501 line too long (80 > 79 characters)'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([2, 3])
+      end
+
+      it { should warn }
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.py:2:13: F812 list comprehension redefines name from line 1'
+        ].join("\n"))
+
+        subject.stub(:modified_lines_in_file).and_return([1, 2])
+      end
+
+      it { should fail_hook }
+    end
   end
 end


### PR DESCRIPTION
Use specific rules to distinguish errors from warnings.

`ERROR_REGEX` taken from https://github.com/SublimeLinter/SublimeLinter-flake8.  The file in question has a copyright notice:

```python
#
# linter.py
# Linter for SublimeLinter3, a code checking framework for Sublime Text 3
#
# Written by Aparajita Fishman
# Copyright (c) 2013 Aparajita Fishman
#
# License: MIT
#
```

How do I properly attribute this in code?