### PR TITLE
Parse errors and warnings in csslint output

### DIFF
--- a/lib/overcommit/hook/pre_commit/css_lint.rb
+++ b/lib/overcommit/hook/pre_commit/css_lint.rb
@@ -1,11 +1,29 @@
 module Overcommit::Hook::PreCommit
   # Runs `csslint` against any modified CSS files.
   class CssLint < Base
+    MESSAGE_REGEX = /
+      ^(?<file>[^:]+):\s
+      (?:line\s(?<line>\d+)[^EW]+)?
+      (?<type>Error|Warning)
+    /x
+
     def run
       result = execute(command + applicable_files)
-      return :pass if result.stdout !~ /Error - (?!Unknown @ rule)/
+      output = result.stdout.chomp
+      return :pass if result.success? && output.empty?
 
-      [:fail, result.stdout]
+      extract_messages(
+        output.split("\n").collect(&method(:add_line_number)),
+        MESSAGE_REGEX,
+        lambda { |type| type.downcase.to_sym }
+      )
+    end
+
+    private
+
+    # Hack to include messages that apply to the entire file
+    def add_line_number(message)
+      message.sub(/(?<!\d,\s)(Error|Warning)/, 'line 0, \1')
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/css_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/css_lint_spec.rb
@@ -9,23 +9,73 @@ describe Overcommit::Hook::PreCommit::CssLint do
     subject.stub(:applicable_files).and_return(%w[file1.css file2.css])
   end
 
-  context 'when csslint exits with no output' do
+  context 'when csslint exits successfully' do
+    let(:result) { double('result') }
+
     before do
-      result = double('result')
-      result.stub(:stdout).and_return('')
+      result.stub(:success?).and_return(true)
       subject.stub(:execute).and_return(result)
     end
 
-    it { should pass }
+    context 'with no output' do
+      before do
+        result.stub(:stdout).and_return('')
+      end
+
+      it { should pass }
+    end
+
+    context 'and it reports a warning' do
+      context 'with a line number' do
+        before do
+          result.stub(:stdout).and_return([
+            'file1.css: line 1, col 5, Warning - Use of !important'
+          ].join("\n"))
+        end
+
+        it { should warn }
+      end
+
+      context 'with no line number' do
+        before do
+          result.stub(:stdout).and_return([
+            'file1.css: Warning - Too many !important declarations (10), try to use less than 10'
+          ].join("\n"))
+        end
+
+        it { should warn }
+      end
+    end
   end
 
-  context 'when csslint exits with output' do
+  context 'when csslint exits unsucessfully' do
+    let(:result) { double('result') }
+
     before do
-      result = double('result')
-      result.stub(:stdout).and_return('Error - @charset not allowed here')
+      result.stub(:success?).and_return(false)
       subject.stub(:execute).and_return(result)
     end
 
-    it { should fail_hook }
+    context 'and it reports an error' do
+      context 'with a line number' do
+        before do
+          result.stub(:stdout).and_return([
+            'file1.css: line 80, col 5, Error - Use of !important'
+          ].join("\n"))
+        end
+
+        it { should fail_hook }
+      end
+
+      context 'with no line number' do
+        before do
+          result.stub(:stdout).and_return([
+            'file1.css: Error - Currently no rules report a rollup error, but that may change'
+          ].join("\n"))
+        end
+
+        it { should fail_hook }
+      end
+    end
   end
 end


### PR DESCRIPTION
Add logic to distinguish between errors and warnings in csslint output.