### PR TITLE
Remove :modified_lines_in_file stubs in pre-commit hook specs

### DIFF
--- a/spec/overcommit/hook/pre_commit/es_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/es_lint_spec.rb
@@ -32,8 +32,6 @@ describe Overcommit::Hook::PreCommit::EsLint do
           '',
           '1 problem'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -55,8 +53,6 @@ describe Overcommit::Hook::PreCommit::EsLint do
           '',
           '1 problem'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/haml_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/haml_lint_spec.rb
@@ -32,8 +32,6 @@ describe Overcommit::Hook::PreCommit::HamlLint do
         result.stub(:stdout).and_return([
           'file1.haml:1 [W] Prefer single quoted strings',
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -44,8 +42,6 @@ describe Overcommit::Hook::PreCommit::HamlLint do
         result.stub(:stdout).and_return([
           'file1.haml:1 [E] Unbalanced brackets.',
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
@@ -44,8 +44,6 @@ describe Overcommit::Hook::PreCommit::JavaCheckstyle do
           'file1.java:1: Missing a Javadoc comment.',
           'Audit done.'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/js_hint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/js_hint_spec.rb
@@ -34,8 +34,6 @@ describe Overcommit::Hook::PreCommit::JsHint do
           '',
           '1 error'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -48,8 +46,6 @@ describe Overcommit::Hook::PreCommit::JsHint do
           '',
           '1 error'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/jscs_spec.rb
+++ b/spec/overcommit/hook/pre_commit/jscs_spec.rb
@@ -34,8 +34,6 @@ describe Overcommit::Hook::PreCommit::Jscs do
         result.stub(:stdout).and_return([
           'file1.js: line 1, col 4, ruleName: Missing space after `if` keyword'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/pep257_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pep257_spec.rb
@@ -33,8 +33,6 @@ describe Overcommit::Hook::PreCommit::Pep257 do
           'file1.py:1 in public method `foo`:',
           '        D102: Docstring missing'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/pep8_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pep8_spec.rb
@@ -32,8 +32,6 @@ describe Overcommit::Hook::PreCommit::Pep8 do
         result.stub(:stdout).and_return([
           'file1.py:1:1: W391 blank line at end of file'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -44,8 +42,6 @@ describe Overcommit::Hook::PreCommit::Pep8 do
         result.stub(:stdout).and_return([
           'file1.py:1:80: E501 line too long (80 > 79 characters)'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/pyflakes_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pyflakes_spec.rb
@@ -32,8 +32,6 @@ describe Overcommit::Hook::PreCommit::Pyflakes do
         result.stub(:stdout).and_return([
           "file1.py:1: local variable 'x' is assigned to but never used"
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -44,8 +42,6 @@ describe Overcommit::Hook::PreCommit::Pyflakes do
         result.stub(:stderr).and_return([
           'file1.py:1:1: invalid syntax'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
+++ b/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
@@ -32,8 +32,6 @@ describe Overcommit::Hook::PreCommit::PythonFlake8 do
         result.stub(:stdout).and_return([
           'file1.py:1:1: W292 no newline at end of file'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -44,8 +42,6 @@ describe Overcommit::Hook::PreCommit::PythonFlake8 do
         result.stub(:stdout).and_return([
           'file1.py:2:13: F812 list comprehension redefines name from line 1'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/reek_spec.rb
+++ b/spec/overcommit/hook/pre_commit/reek_spec.rb
@@ -34,8 +34,6 @@ describe Overcommit::Hook::PreCommit::Reek do
           'file1.rb:1: MyClass#my_method performs a nil-check. (NilCheck)'
         ].join("\n"))
         result.stub(:stderr).and_return('')
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/rubocop_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rubocop_spec.rb
@@ -33,8 +33,6 @@ describe Overcommit::Hook::PreCommit::Rubocop do
           'file1.rb:1:1: W: Useless assignment to variable - my_var.',
         ].join("\n"))
         result.stub(:stderr).and_return('')
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -46,8 +44,6 @@ describe Overcommit::Hook::PreCommit::Rubocop do
           'file1.rb:1:1: C: Missing top-level class documentation',
         ].join("\n"))
         result.stub(:stderr).and_return('')
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/scalastyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/scalastyle_spec.rb
@@ -39,8 +39,6 @@ describe Overcommit::Hook::PreCommit::Scalastyle do
           'Found 1 warnings',
           'Finished in 490 ms'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -64,8 +62,6 @@ describe Overcommit::Hook::PreCommit::Scalastyle do
           'Found 0 warnings',
           'Finished in 490 ms'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/scss_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/scss_lint_spec.rb
@@ -32,8 +32,6 @@ describe Overcommit::Hook::PreCommit::ScssLint do
         result.stub(:stdout).and_return([
           'file1.scss:1 [W] Prefer single quoted strings',
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -44,8 +42,6 @@ describe Overcommit::Hook::PreCommit::ScssLint do
         result.stub(:stdout).and_return([
           'file1.scss:1 [E] Syntax Error: Invalid CSS',
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
@@ -33,8 +33,6 @@ describe Overcommit::Hook::PreCommit::SemiStandard do
           'Error: Code style check failed:',
           'file1.js:1:1: Extra semicolon. (eslint/semi)'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/shell_check_spec.rb
+++ b/spec/overcommit/hook/pre_commit/shell_check_spec.rb
@@ -34,8 +34,6 @@ describe Overcommit::Hook::PreCommit::ShellCheck do
            options. [SC2035]",
         ].join("\n"))
         result.stub(:stderr).and_return('')
-
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -48,8 +46,6 @@ describe Overcommit::Hook::PreCommit::ShellCheck do
            won't interpret it. [SC2061]",
         ].join("\n"))
         result.stub(:stderr).and_return('')
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/standard_spec.rb
@@ -33,8 +33,6 @@ describe Overcommit::Hook::PreCommit::Standard do
           'Error: Use JavaScript Standard Style (https://github.com/feross/standard)',
           'file1.js:1:1: Extra semicolon. (eslint/semi)'
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/w3c_css_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_css_spec.rb
@@ -56,7 +56,6 @@ describe Overcommit::Hook::PreCommit::W3cCss do
       before do
         message.stub(type: :warning, line: '1', message: '')
         results.stub(errors: [], warnings: [message])
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -66,7 +65,6 @@ describe Overcommit::Hook::PreCommit::W3cCss do
       before do
         message.stub(type: :error, line: '1', message: '')
         results.stub(errors: [message], warnings: [])
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/w3c_html_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_html_spec.rb
@@ -56,7 +56,6 @@ describe Overcommit::Hook::PreCommit::W3cHtml do
       before do
         message.stub(type: :warning, line: '1', message: '')
         results.stub(errors: [], warnings: [message])
-        subject.stub(:modified_lines_in_file).and_return([2, 3])
       end
 
       it { should warn }
@@ -66,7 +65,6 @@ describe Overcommit::Hook::PreCommit::W3cHtml do
       before do
         message.stub(type: :error, line: '1', message: '')
         results.stub(errors: [message], warnings: [])
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/xml_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/xml_lint_spec.rb
@@ -39,8 +39,6 @@ describe Overcommit::Hook::PreCommit::XmlLint do
         result.stub(:stderr).and_return([
           "file1.xml:1: parser error : expected '='"
         ].join("\n"))
-
-        subject.stub(:modified_lines_in_file).and_return([1, 2])
       end
 
       it { should fail_hook }


### PR DESCRIPTION
Pre-commit hook specs never use this method, so these lines just create cruft and could be misleading to someone reading or modifying the specs (read: myself).

To clarify, the hook specs directly check the output of `run` without any processing to filter out unmodified lines.