### PR TITLE
LocalPathsInGemfile ignores commented local paths

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -189,7 +189,7 @@ PreCommit:
   LocalPathsInGemfile:
     description: 'Checking for local paths in Gemfile'
     required_executable: 'grep'
-    flags: ['-IHnE', '(\bpath:)|(:path\s*=>)']
+    flags: ['-IHnE', '^[^#]*((\bpath:)|(:path\s*=>))']
     include: '**/Gemfile'
 
   MergeConflicts:

--- a/spec/overcommit/hook/pre_commit/local_paths_in_gemfile_spec.rb
+++ b/spec/overcommit/hook/pre_commit/local_paths_in_gemfile_spec.rb
@@ -60,4 +60,16 @@ describe Overcommit::Hook::PreCommit::LocalPathsInGemfile do
 
     it { should pass }
   end
+
+  context 'when the file contains local paths, but only in comments' do
+    let(:contents) do
+      [ "# gem 'fuubar', :path => '../fuubar'" ,
+        "# :path => '../fuubar'" ,
+        "# gem 'fuubar', path: '../fuubar'" ,
+        "# path: '../fuubar'" ,
+      ].join("\n")
+    end
+
+    it { should pass }
+  end
 end


### PR DESCRIPTION
We use a local path for development constantly, and leave it commented in the Gemfile. It seems appropriate to me that the git hook shouldn't mind finding a local path in a gemfile if it's in a comment.