### PR TITLE
Ignore blank lines in csslint output

### DIFF
--- a/lib/overcommit/hook/pre_commit/css_lint.rb
+++ b/lib/overcommit/hook/pre_commit/css_lint.rb
@@ -13,7 +13,7 @@ module Overcommit::Hook::PreCommit
       return :pass if result.success? && output.empty?
 
       extract_messages(
-        output.split("\n").collect(&method(:add_line_number)),
+        output.split("\n").reject(&:empty?).collect(&method(:add_line_number)),
         MESSAGE_REGEX,
         lambda { |type| type.downcase.to_sym }
       )


### PR DESCRIPTION
csslint outputs errors as blocks for each file, with a blank line separating them. Including these lines in the call to `extract_messages` results in the error:
```
Unexpected output: unable to determine line number or type of error/warning for message
```