### PR TITLE
Allow extraction of messages with no line number

### DIFF
--- a/lib/overcommit/hook/pre_commit/base.rb
+++ b/lib/overcommit/hook/pre_commit/base.rb
@@ -32,7 +32,7 @@ module Overcommit::Hook::PreCommit
         end
 
         file = extract_file(match, message)
-        line = extract_line(match, message)
+        line = extract_line(match, message) unless match[:line].nil?
         type = extract_type(match, message, type_categorizer)
 
         Overcommit::Hook::Message.new(type, file, line, message)

--- a/lib/overcommit/hook/pre_commit/css_lint.rb
+++ b/lib/overcommit/hook/pre_commit/css_lint.rb
@@ -13,17 +13,10 @@ module Overcommit::Hook::PreCommit
       return :pass if result.success? && output.empty?
 
       extract_messages(
-        output.split("\n").reject(&:empty?).collect(&method(:add_line_number)),
+        output.split("\n").reject(&:empty?),
         MESSAGE_REGEX,
         lambda { |type| type.downcase.to_sym }
       )
-    end
-
-    private
-
-    # Hack to include messages that apply to the entire file
-    def add_line_number(message)
-      message.sub(/(?<!\d,\s)(Error|Warning)/, 'line 0, \1')
     end
   end
 end


### PR DESCRIPTION
Some linters output file-level errors that don't correspond to a
specific line number. Previously, this was only workable by either
manually building the Overcommit::Hook::Message instance or
splicing a dummy line number into the output.