### PR TITLE
Extract file, line, type from coffeelint output

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -114,6 +114,7 @@ PreCommit:
   CoffeeLint:
     description: 'Analyzing with coffeelint'
     required_executable: 'coffeelint'
+    required_library: 'json'
     flags: ['--reporter=raw']
     install_command: 'npm install -g coffeelint'
     include: '**/*.coffee'

--- a/config/default.yml
+++ b/config/default.yml
@@ -114,7 +114,7 @@ PreCommit:
   CoffeeLint:
     description: 'Analyzing with coffeelint'
     required_executable: 'coffeelint'
-    flags: ['--quiet']
+    flags: ['--reporter=raw']
     install_command: 'npm install -g coffeelint'
     include: '**/*.coffee'
 

--- a/lib/overcommit/hook/pre_commit/coffee_lint.rb
+++ b/lib/overcommit/hook/pre_commit/coffee_lint.rb
@@ -1,11 +1,40 @@
+require 'json'
+
 module Overcommit::Hook::PreCommit
   # Runs `coffeelint` against any modified CoffeeScript files.
   class CoffeeLint < Base
     def run
       result = execute(command + applicable_files)
-      return :pass if result.success?
 
-      [:fail, result.stdout]
+      begin
+        parse_json_messages(result.stdout)
+      rescue JSON::ParserError => e
+        [:fail, "Error parsing coffeelint output: #{e.message}"]
+      end
+    end
+
+    private
+
+    def parse_json_messages(output)
+      JSON.parse(output).collect do |file, messages|
+        messages.collect { |msg| extract_message(file, msg) }
+      end.flatten
+    end
+
+    def extract_message(file, message_hash)
+      type = message_hash['level'].include?('w') ? :warning : :error
+      line = message_hash['lineNumber']
+      rule = message_hash['rule']
+      msg = message_hash['message']
+      text =
+        if rule == 'coffeescript_error'
+          # Syntax errors are output in different format.
+          # Splice in the file name and grab the first line.
+          msg.sub('[stdin]', file).split("\n")[0]
+        else
+          "#{file}:#{line}: #{msg} (#{rule})"
+        end
+      Overcommit::Hook::Message.new(type, file, line, text)
     end
   end
 end

--- a/lib/overcommit/hook/pre_commit/coffee_lint.rb
+++ b/lib/overcommit/hook/pre_commit/coffee_lint.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module Overcommit::Hook::PreCommit
   # Runs `coffeelint` against any modified CoffeeScript files.
   class CoffeeLint < Base


### PR DESCRIPTION
Use `raw` JSON reporter to extract information from coffeelint messages. There is no one-line reporter, so this is the best we can do. There is a `csv` reporter, but it's not as safe since syntax error messages include newlines and unicode.