### PR TITLE
Ignore hard tabs in Godeps.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix `CssLint` pre-commit hook to ignore blank lines in `csslint` output
 * Switch `ImageOptim` hook to use executable instead of Ruby API
 * Fix error instructions typo in `BundleCheck` pre-commit hook
+* Ignore hard tabs in `Godeps/Godeps.json` by default
 
 ## 0.23.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -151,6 +151,7 @@ PreCommit:
     flags: ['-IHn', "\t"]
     exclude:
       - '**/*.go'
+      - 'Godeps/Godeps.json'
       - '**/Makefile'
       - '.gitmodules'
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -151,9 +151,9 @@ PreCommit:
     flags: ['-IHn', "\t"]
     exclude:
       - '**/*.go'
-      - 'Godeps/Godeps.json'
       - '**/Makefile'
       - '.gitmodules'
+      - 'Godeps/Godeps.json'
 
   HtmlTidy:
     enabled: false


### PR DESCRIPTION
Godep is a utility for managing Go dependencies. It uses the default
JSON marshaller to automatically save this file (should never be
hand-edited). We should not error out or this, since we have no control
over it (and even if we un-tabbed it, it would be re-tabbed next time we
change our dependencies).

Here is a sample error I get:
```
$ git commit -m "bump sqlite3"
Running pre-commit hooks
Checking for hard tabs.....................................[HardTabs] FAILED
Hard tabs detected:
/Users/aiden/src/gocode/src/uber/uberalls/Godeps/Godeps.json:2: "ImportPath": "uber/uberalls",
/Users/aiden/src/gocode/src/uber/uberalls/Godeps/Godeps.json:3: "GoVersion": "go1.4",
/Users/aiden/src/gocode/src/uber/uberalls/Godeps/Godeps.json:4: "Deps": [