### PR TITLE
Extract file, line from golint output

### DIFF
--- a/lib/overcommit/hook/pre_commit/go_lint.rb
+++ b/lib/overcommit/hook/pre_commit/go_lint.rb
@@ -3,10 +3,16 @@ module Overcommit::Hook::PreCommit
   class GoLint < Base
     def run
       result = execute(command + applicable_files)
+      output = result.stdout
       # Unfortunately the exit code is always 0
-      return :pass if result.stdout.empty?
+      return :pass if output.empty?
 
-      [:fail, result.stdout]
+      # example message:
+      #   path/to/file.go:1:1: Error message
+      extract_messages(
+        output.split("\n"),
+        /^(?<file>[^:]+):(?<line>\d+)/
+      )
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/go_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/go_lint_spec.rb
@@ -10,30 +10,28 @@ describe Overcommit::Hook::PreCommit::GoLint do
   end
 
   context 'when golint exits successfully' do
+    let(:result) { double('result') }
+
     before do
-      stdout = double('tempfile')
-      stdout.stub(:empty?).and_return(true)
-
-      result = double('result')
-      result.stub(:stdout).and_return(stdout)
-
       subject.stub(:execute).and_return(result)
     end
 
-    it { should pass }
-  end
+    context 'with no output' do
+      before do
+        result.stub(:stdout).and_return('')
+      end
 
-  context 'when golint exits with stdout' do
-    before do
-      stdout = double('tempfile')
-      stdout.stub(:empty?).and_return(false)
-
-      result = double('result')
-      result.stub(:stdout).and_return(stdout)
-
-      subject.stub(:execute).and_return(result)
+      it { should pass }
     end
 
-    it { should fail_hook }
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.go:1:1: error should be the last type when returning multiple items'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
+    end
   end
 end


### PR DESCRIPTION
This and #118 cover the last linter hooks whose message info is not extracted from the output.