### PR TITLE
Exclude Markdown files from TrailingWhitespace

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -323,6 +323,8 @@ PreCommit:
     description: 'Checking for trailing whitespace'
     required_executable: 'grep'
     flags: ['-IHn', '\s$']
+    exclude:
+      - '**/*.md'
 
   TravisLint:
     description: 'Checking Travis CI configuration'


### PR DESCRIPTION
Two trailing spaces are used to force a line break in Markdown files.

Change-Id: I6aea9d7b3da14381dd2fcf7f80648a419ba70ac5