### PR TITLE
Add pre-commit hook for JSL (JavaScript Lint)

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -192,6 +192,12 @@ PreCommit:
     install_command: 'npm install -g jshint'
     include: '**/*.js'
 
+  Jsl:
+    description: 'Analyzing with JSL'
+    required_executable: 'jsl'
+    flags: ['-nologo', '-nofilelisting', '-nocontext', '-nosummary']
+    include: '**/*.js'
+
   JsonSyntax:
     description: 'Validating JSON syntax'
     required_library: 'json'

--- a/lib/overcommit/hook/pre_commit/jsl.rb
+++ b/lib/overcommit/hook/pre_commit/jsl.rb
@@ -1,0 +1,24 @@
+module Overcommit::Hook::PreCommit
+  # Runs `jsl` against any modified JavaScript files.
+  class Jsl < Base
+    MESSAGE_REGEX = /(?<file>.+)\((?<line>\d+)\):(?<type>[^:]+)/
+
+    MESSAGE_TYPE_CATEGORIZER = lambda do |type|
+      type =~ /warning/ ? :warning : :error
+    end
+
+    def run
+      file_flags = applicable_files.map { |file| ['-process', file] }
+      result = execute(command + file_flags.flatten)
+      return :pass if result.success?
+
+      # example message:
+      #   path/to/file.js(1): lint warning: Error message
+      extract_messages(
+        result.stdout.split("\n").grep(MESSAGE_REGEX),
+        MESSAGE_REGEX,
+        MESSAGE_TYPE_CATEGORIZER
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/jsl_spec.rb
+++ b/spec/overcommit/hook/pre_commit/jsl_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Jsl do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.js file2.js])
+  end
+
+  context 'when jsl exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when jsl exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports a warning' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.js(1): lint warning: meaningless block; curly braces have no impact'
+        ].join("\n"))
+      end
+
+      it { should warn }
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.js(1): SyntaxError: invalid label'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
[JavaScript Lint](http://www.javascriptlint.com) is a static analyzer in the vein of JSLint, JSHint, etc.

Unfortunately this tool is not available through a cross-platform package manager, so no `install_command`. The `javascriptlint` package on `npm` is unmaintained (no commits in 3 years) and does not provide an executable.

If you're on a Mac, though, you can get it with `brew install jsl` :smile: 