### PR TITLE
Handle Golint errors output to stderr

### DIFF
--- a/lib/overcommit/hook/pre_commit/go_lint.rb
+++ b/lib/overcommit/hook/pre_commit/go_lint.rb
@@ -3,7 +3,7 @@ module Overcommit::Hook::PreCommit
   class GoLint < Base
     def run
       result = execute(command + applicable_files)
-      output = result.stdout
+      output = result.stdout + result.stderr
       # Unfortunately the exit code is always 0
       return :pass if output.empty?
 

--- a/spec/overcommit/hook/pre_commit/go_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/go_lint_spec.rb
@@ -18,20 +18,32 @@ describe Overcommit::Hook::PreCommit::GoLint do
 
     context 'with no output' do
       before do
-        result.stub(:stdout).and_return('')
+        result.stub(stdout: '', stderr: '')
       end
 
       it { should pass }
     end
 
     context 'and it reports an error' do
-      before do
-        result.stub(:stdout).and_return([
-          'file1.go:1:1: error should be the last type when returning multiple items'
-        ].join("\n"))
+      context 'on stdout' do
+        before do
+          result.stub(stderr: '', stdout:
+            'file1.go:1:1: error should be the last type when returning multiple items'
+          )
+        end
+
+        it { should fail_hook }
       end
 
-      it { should fail_hook }
+      context 'on stderr' do
+        before do
+          result.stub(stdout: '', stderr:
+            "file1.go:1:1: expected 'package', found 'IDENT' foo"
+          )
+        end
+
+        it { should fail_hook }
+      end
     end
   end
 end


### PR DESCRIPTION
Standard lint errors are output to `stdout`, but syntax errors, and runtime errors in general, are output to `stderr`.