### PR TITLE
Add GoVet pre-commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Add `Jsl` pre-commit hook that checks the style of JavaScript files with
   [JavaScript Lint](http://www.javascriptlint.com/)
 * Add `CapitalizedSubject` commit message hook
+* Add `GoVet` pre-commit hook
 
 ## 0.23.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -142,6 +142,13 @@ PreCommit:
     install_command: 'go get github.com/golang/lint/golint'
     include: '**/*.go'
 
+  GoVet:
+    description: 'Analyzing with go vet'
+    required_executable: 'go'
+    flags: ['tool', 'vet']
+    install_command: 'go get golang.org/x/tools/cmd/vet'
+    include: '**/*.go'
+
   HamlLint:
     description: 'Analyzing with haml-lint'
     required_executable: 'haml-lint'

--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -196,12 +196,17 @@ module Overcommit::Hook
       return unless required_executable && !in_path?(required_executable)
 
       output = "'#{required_executable}' is not installed (or is not in your PATH)"
-
-      if install_command = @config['install_command']
-        output += "\nInstall it by running: #{install_command}"
-      end
+      output << install_command_prompt
 
       output
+    end
+
+    def install_command_prompt
+      if install_command = @config['install_command']
+        "\nInstall it by running: #{install_command}"
+      else
+        ''
+      end
     end
 
     # If the hook defines required library paths that it wants to load, attempt

--- a/lib/overcommit/hook/pre_commit/go_vet.rb
+++ b/lib/overcommit/hook/pre_commit/go_vet.rb
@@ -1,0 +1,20 @@
+module Overcommit::Hook::PreCommit
+  # Runs `go vet` against any modified Golang files.
+  class GoVet < Base
+    def run
+      result = execute(command + applicable_files)
+      return :pass if result.success?
+
+      if result.stderr =~ /no such tool "vet"/
+        return :fail, "`go tool vet` is not installed#{install_command_prompt}"
+      end
+
+      # example message:
+      #   path/to/file.go:7: Error message
+      extract_messages(
+        result.stderr.split("\n"),
+        /^(?<file>[^:]+):(?<line>\d+)/
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/go_vet_spec.rb
+++ b/spec/overcommit/hook/pre_commit/go_vet_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::GoVet do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.go file2.go])
+  end
+
+  context 'when go vet exits successfully' do
+
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when go vet exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'when go tool vet is not installed' do
+      before do
+        result.stub(stderr:
+          'go tool: no such tool "vet"; to install:'
+        )
+      end
+
+      it { should fail_hook /is not installed/ }
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(stderr:
+          'file1.go:1: possible formatting directive in Print call'
+        )
+      end
+
+      it { should fail_hook /formatting directive/ }
+    end
+  end
+end


### PR DESCRIPTION
From the docs:

    https://godoc.org/golang.org/x/tools/cmd/vet

    Vet examines Go source code and reports suspicious constructs, such
    as Printf calls whose arguments do not align with the format
    string. Vet uses heuristics that do not guarantee all reports are
    genuine problems, but it can find errors not caught by the
    compilers.

Note some shennanigans around detecting whether the tool is installed. When you run `go get golang.org/x/tools/cmd/vet` it does not install a binary in your path; rather you invoke it with `go tool vet` which will exit with an error message if the utility is not installed. I am not sure if there is prior art in this repo for doing this in a better way; please feel free to suggest one!