### PR TITLE
Add simplecov coverage tool to spec runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 pkg/
 .bundle
+coverage

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'travis', '~> 1.7'
   s.add_development_dependency 'w3c_validators', '~> 1.2'
+  s.add_development_dependency 'simplecov', '~> 0.9.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require 'overcommit'
 require 'tempfile'
 
+require 'simplecov'
+SimpleCov.start
+
 hook_types = Dir[File.join(Overcommit::OVERCOMMIT_HOME, 'lib/overcommit/hook/*')].
   select { |f| File.directory?(f) }.
   sort


### PR DESCRIPTION
I'm out of the Ruby game, so this may be the wrong tool, but when
contributing code I like to know that my change is well-tested. I tried
simplecov and it worked nicely. Perhaps this would be useful for others?

Example report: http://sca.ndella.com/overcommit-coverage/index.html#_AllFiles