### PR TITLE
Add pre-commit hook to check for case conflicts

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -104,6 +104,10 @@ PreCommit:
       - 'Gemfile.lock'
       - '*.gemspec'
 
+  CaseConflicts:
+    description: 'Checking for case-insensitivity conflicts'
+    quiet: true
+
   ChamberSecurity:
     enabled: false
     description: 'Checking that settings have been secured with Chamber'

--- a/lib/overcommit/git_repo.rb
+++ b/lib/overcommit/git_repo.rb
@@ -54,6 +54,19 @@ module Overcommit
         map { |relative_file| File.expand_path(relative_file) }
     end
 
+    # Returns the names of files in the given paths that are tracked by git.
+    #
+    # @param paths [Array<String>] list of paths to check
+    # @option options [String] ref ('HEAD') Git ref to check
+    # @return [Array<String>] list of absolute file paths
+    def list_files(paths = [], options = {})
+      ref = options[:ref] || 'HEAD'
+      `git ls-tree --name-only #{ref} #{paths.join(' ')}`.
+        split(/\n/).
+        map { |relative_file| File.expand_path(relative_file) }.
+        reject { |file| File.directory?(file) } # Exclude submodule directories
+    end
+
     # Returns the names of all files that are tracked by git.
     #
     # @return [Array<String>] list of absolute file paths

--- a/lib/overcommit/hook/pre_commit/case_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/case_conflicts.rb
@@ -8,7 +8,7 @@ module Overcommit::Hook::PreCommit
       conflict_hash = repo_files.classify(&:downcase).
         select { |_, files| files.size > 1 }
       conflict_files = applicable_files.
-        select { |file| conflict_hash.include? file.downcase }
+        select { |file| conflict_hash.include?(file.downcase) }
 
       conflict_files.map do |file|
         conflicts = conflict_hash[file.downcase].map { |f| File.basename(f) }

--- a/lib/overcommit/hook/pre_commit/case_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/case_conflicts.rb
@@ -3,7 +3,8 @@ module Overcommit::Hook::PreCommit
   # Adapted from https://github.com/pre-commit/pre-commit-hooks
   class CaseConflicts < Base
     def run
-      repo_files = Set.new(Overcommit::GitRepo.all_files)
+      paths = Set.new(applicable_files.map { |file| File.dirname(file) })
+      repo_files = Set.new(Overcommit::GitRepo.list_files(paths.to_a) + applicable_files)
       conflict_hash = repo_files.classify(&:downcase).
         select { |_, files| files.size > 1 }
       conflict_files = applicable_files.

--- a/lib/overcommit/hook/pre_commit/case_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/case_conflicts.rb
@@ -1,0 +1,19 @@
+module Overcommit::Hook::PreCommit
+  # Checks for files that would conflict in case-insensitive filesystems
+  # Adapted from https://github.com/pre-commit/pre-commit-hooks
+  class CaseConflicts < Base
+    def run
+      repo_files = Set.new(Overcommit::GitRepo.all_files)
+      conflict_hash = repo_files.classify(&:downcase).
+        select { |_, files| files.size > 1 }
+      conflict_files = applicable_files.
+        select { |file| conflict_hash.include? file.downcase }
+
+      conflict_files.map do |file|
+        conflicts = conflict_hash[file.downcase].map { |f| File.basename(f) }
+        msg = "Case-insensitivity conflict detected: #{conflicts.join(', ')}"
+        Overcommit::Hook::Message.new(:error, file, nil, msg)
+      end
+    end
+  end
+end

--- a/lib/overcommit/hook/pre_commit/case_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/case_conflicts.rb
@@ -11,7 +11,7 @@ module Overcommit::Hook::PreCommit
 
       conflict_files.map do |file|
         conflicts = conflict_hash[file.downcase].map { |f| File.basename(f) }
-        msg = "Case-insensitivity conflict detected: #{conflicts.join(', ')}"
+        msg = "Conflict detected for case-insensitive file systems: #{conflicts.join(', ')}"
         Overcommit::Hook::Message.new(:error, file, nil, msg)
       end
     end

--- a/lib/overcommit/hook/pre_commit/case_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/case_conflicts.rb
@@ -3,7 +3,7 @@ module Overcommit::Hook::PreCommit
   # Adapted from https://github.com/pre-commit/pre-commit-hooks
   class CaseConflicts < Base
     def run
-      paths = Set.new(applicable_files.map { |file| File.dirname(file) })
+      paths = Set.new(applicable_files.map { |file| File.dirname(file) + File::SEPARATOR })
       repo_files = Set.new(Overcommit::GitRepo.list_files(paths.to_a) + applicable_files)
       conflict_hash = repo_files.classify(&:downcase).
         select { |_, files| files.size > 1 }

--- a/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
+++ b/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
@@ -6,7 +6,7 @@ describe Overcommit::Hook::PreCommit::CaseConflicts do
   subject { described_class.new(config, context) }
 
   before do
-    Overcommit::GitRepo.stub(:all_files) { %w[foo] + subject.applicable_files }
+    Overcommit::GitRepo.stub(:list_files).and_return(%w[foo])
   end
 
   context 'when a new file conflicts with an existing file' do

--- a/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
+++ b/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::CaseConflicts do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    Overcommit::GitRepo.stub(:all_files) { %w[foo] + subject.applicable_files }
+  end
+
+  context 'when a new file conflicts with an existing file' do
+    before do
+      subject.stub(:applicable_files).and_return(%w[Foo])
+    end
+
+    it { should fail_hook }
+  end
+
+  context 'when a new file conflicts with another new file' do
+    before do
+      subject.stub(:applicable_files).and_return(%w[bar Bar])
+    end
+
+    it { should fail_hook }
+  end
+
+  context 'when there are no conflicts' do
+    before do
+      subject.stub(:applicable_files).and_return(%w[bar baz])
+    end
+
+    it { should pass }
+  end
+end


### PR DESCRIPTION
Files with the same name but different capitalization can cause
trouble on case-insensitive filesystems.