### PR TITLE
Save old hooks on install, restore on uninstall

### DIFF
--- a/lib/overcommit/installer.rb
+++ b/lib/overcommit/installer.rb
@@ -144,7 +144,7 @@ module Overcommit
 
       Dir.chdir(old_hooks_path) do
         Overcommit::Utils.supported_hook_types.each do |hook_type|
-          FileUtils.mv(hook_type, hooks_path)
+          FileUtils.mv(hook_type, hooks_path) if File.exist?(hook_type)
         end
       end
       # Remove old-hooks directory if empty

--- a/lib/overcommit/installer.rb
+++ b/lib/overcommit/installer.rb
@@ -132,6 +132,8 @@ module Overcommit
       Overcommit::Utils.supported_hook_types.each do |hook_type|
         hook_file = File.join(hooks_path, hook_type)
         unless can_replace_file?(hook_file)
+          log.warning "Hook '#{File.expand_path(hook_type)}' already exists and " \
+                      "was not installed by Overcommit. Moving to '#{old_hooks_path}'"
           FileUtils.mv(hook_file, old_hooks_path)
         end
       end
@@ -142,6 +144,8 @@ module Overcommit
     def restore_old_hooks
       return unless File.directory?(old_hooks_path)
 
+      log.log "Restoring old hooks from #{old_hooks_path}"
+
       Dir.chdir(old_hooks_path) do
         Overcommit::Utils.supported_hook_types.each do |hook_type|
           FileUtils.mv(hook_type, hooks_path) if File.exist?(hook_type)
@@ -149,6 +153,8 @@ module Overcommit
       end
       # Remove old-hooks directory if empty
       FileUtils.rmdir(old_hooks_path)
+
+      log.success "Successfully restored old hooks from #{old_hooks_path}"
     end
 
     def uninstall_hook_symlinks

--- a/lib/overcommit/installer.rb
+++ b/lib/overcommit/installer.rb
@@ -42,8 +42,8 @@ module Overcommit
     def uninstall
       log.log "Removing hooks from #{@target}"
 
-      uninstall_master_hook
       uninstall_hook_symlinks
+      uninstall_master_hook
       restore_old_hooks
 
       log.success "Successfully removed hooks from #{@target}"

--- a/lib/overcommit/installer.rb
+++ b/lib/overcommit/installer.rb
@@ -135,6 +135,8 @@ module Overcommit
           FileUtils.mv(hook_file, old_hooks_path)
         end
       end
+      # Remove old-hooks directory if empty
+      FileUtils.rmdir(old_hooks_path)
     end
 
     def restore_old_hooks
@@ -145,6 +147,7 @@ module Overcommit
           FileUtils.mv(hook_type, hooks_path)
         end
       end
+      # Remove old-hooks directory if empty
       FileUtils.rmdir(old_hooks_path)
     end
 

--- a/lib/overcommit/installer.rb
+++ b/lib/overcommit/installer.rb
@@ -30,7 +30,8 @@ module Overcommit
     def install
       log.log "Installing hooks into #{@target}"
 
-      ensure_hooks_directory
+      ensure_directory(hooks_path)
+      preserve_old_hooks
       install_master_hook
       install_hook_symlinks
       install_starter_config
@@ -43,6 +44,7 @@ module Overcommit
 
       uninstall_master_hook
       uninstall_hook_symlinks
+      restore_old_hooks
 
       log.success "Successfully removed hooks from #{@target}"
     end
@@ -50,6 +52,7 @@ module Overcommit
     # @return [true,false] whether the hooks were updated
     def update
       unless FileUtils.compare_file(MASTER_HOOK, master_hook_install_path)
+        preserve_old_hooks
         install_master_hook
         install_hook_symlinks
 
@@ -63,12 +66,16 @@ module Overcommit
       File.join(Overcommit::Utils.git_dir(absolute_target), 'hooks')
     end
 
+    def old_hooks_path
+      File.join(hooks_path, 'old-hooks')
+    end
+
     def master_hook_install_path
       File.join(hooks_path, 'overcommit-hook')
     end
 
-    def ensure_hooks_directory
-      FileUtils.mkdir_p(hooks_path)
+    def ensure_directory(path)
+      FileUtils.mkdir_p(path)
     end
 
     def validate_target
@@ -116,6 +123,29 @@ module Overcommit
       @options[:force] ||
         !File.exist?(file) ||
         overcommit_hook?(file)
+    end
+
+    def preserve_old_hooks
+      return unless File.directory?(hooks_path)
+
+      ensure_directory(old_hooks_path)
+      Overcommit::Utils.supported_hook_types.each do |hook_type|
+        hook_file = File.join(hooks_path, hook_type)
+        unless can_replace_file?(hook_file)
+          FileUtils.mv(hook_file, old_hooks_path)
+        end
+      end
+    end
+
+    def restore_old_hooks
+      return unless File.directory?(old_hooks_path)
+
+      Dir.chdir(old_hooks_path) do
+        Overcommit::Utils.supported_hook_types.each do |hook_type|
+          FileUtils.mv(hook_type, hooks_path)
+        end
+      end
+      FileUtils.rmdir(old_hooks_path)
     end
 
     def uninstall_hook_symlinks

--- a/spec/overcommit/installer_spec.rb
+++ b/spec/overcommit/installer_spec.rb
@@ -27,6 +27,7 @@ describe Overcommit::Installer do
     context 'when the target is a git repo' do
       let(:target) { repo }
       let(:hooks_dir) { File.join(target, '.git', 'hooks') }
+      let(:old_hooks_dir) { File.join(hooks_dir, 'old-hooks') }
 
       context 'and an install is requested' do
         context 'and Overcommit hooks were not previously installed' do
@@ -64,16 +65,25 @@ describe Overcommit::Installer do
         end
 
         context 'and non-Overcommit hooks were previously installed' do
+          let(:old_hooks) { %w[commit-msg pre-commit] }
+
           before do
             FileUtils.mkdir_p(hooks_dir)
             Dir.chdir(hooks_dir) do
-              FileUtils.touch('commit-msg')
-              FileUtils.touch('pre-commit')
+              old_hooks.each { |hook_type| FileUtils.touch(hook_type) }
             end
           end
 
-          it 'raises an error' do
-            expect { subject }.to raise_error Overcommit::Exceptions::PreExistingHooks
+          it 'does not raise an error' do
+            expect { subject }.to_not raise_error
+          end
+
+          it 'moves them to a subdirectory' do
+            expect { subject }.to change {
+              old_hooks.all? do |hook_type|
+                File.exist?(File.join(old_hooks_dir, hook_type))
+              end
+            }.from(false).to(true)
           end
 
           context 'and the force option is specified' do
@@ -155,20 +165,40 @@ describe Overcommit::Installer do
         end
 
         context 'and non-Overcommit hooks were previously installed' do
-          before do
-            FileUtils.mkdir_p(hooks_dir)
-            Dir.chdir(hooks_dir) do
-              FileUtils.touch('commit-msg')
-              FileUtils.touch('pre-commit')
+          let(:old_hooks) { %w[commit-msg pre-commit] }
+
+          context 'before installing Overcommit hooks' do
+            before do
+              FileUtils.mkdir_p(old_hooks_dir)
+              Dir.chdir(old_hooks_dir) do
+                old_hooks.each { |hook_type| FileUtils.touch(hook_type) }
+              end
+            end
+
+            it 'restores the previously existing hooks' do
+              expect { subject }.to change {
+                old_hooks.all? do |hook_type|
+                  File.exist?(File.join(hooks_dir, hook_type))
+                end
+              }.from(false).to(true)
             end
           end
 
-          it 'does not remove the previously existing hooks' do
-            expect { subject }.to_not change {
-              %w[commit-msg pre-commit].all? do |hook_type|
-                File.exist?(File.join(hooks_dir, hook_type))
+          context 'after installing Overcommit hooks' do
+            before do
+              FileUtils.mkdir_p(hooks_dir)
+              Dir.chdir(hooks_dir) do
+                old_hooks.each { |hook_type| FileUtils.touch(hook_type) }
               end
-            }
+            end
+
+            it 'does not remove the previously existing hooks' do
+              expect { subject }.to_not change {
+                old_hooks.all? do |hook_type|
+                  File.exist?(File.join(hooks_dir, hook_type))
+                end
+              }
+            end
           end
         end
       end

--- a/spec/overcommit/installer_spec.rb
+++ b/spec/overcommit/installer_spec.rb
@@ -152,7 +152,8 @@ describe Overcommit::Installer do
           it 'removes all symlinks from the hooks directory' do
             expect { subject }.to change {
               Overcommit::Utils.supported_hook_types.all? do |hook_type|
-                File.exist?(File.join(hooks_dir, hook_type))
+                hook_file = File.join(hooks_dir, hook_type)
+                File.exist?(hook_file) || File.symlink?(hook_file)
               end
             }.from(true).to(false)
           end


### PR DESCRIPTION
Save existing hooks in '.git/hooks/old-hooks' when running `overcommit --install`, and restore them to `.git/hooks` on `overcommit --uninstall`.

Also remove hook symlinks before the master hook on uninstall.

Closes #138
Closes #140