### PR TITLE
Filter out irrelevant directories in SimpleCov reports

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,6 @@
+SimpleCov.start do
+  add_filter 'bin/'
+  add_filter 'libexec/'
+  add_filter 'spec/'
+  add_filter 'template-dir/'
+end


### PR DESCRIPTION
Currently, the coverage data reported to Coveralls includes lines in RSpec helper files, which inflates the coverage percentage.

This config file for `SimpleCov` filters out files in the listed directories so that coverage is not artificially inflated.