### PR TITLE
Properly handle submodule-only changes

### DIFF
--- a/lib/overcommit/hook_context/pre_commit.rb
+++ b/lib/overcommit/hook_context/pre_commit.rb
@@ -31,7 +31,8 @@ module Overcommit::HookContext
                 "\nSTDOUT:#{result.stdout}\nSTDERR:#{result.stderr}"
         end
 
-        @changes_stashed = true
+        # False if only submodule references were changed
+        @changes_stashed = modified_files.any?
       end
 
       # While running the hooks make it appear as if nothing changed

--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -66,6 +66,30 @@ describe Overcommit::HookContext::PreCommit do
       end
     end
 
+    context 'when only a submodule change is staged' do
+      around do |example|
+        submodule = repo do
+          `git commit --allow-empty -m "Initial commit"`
+        end
+
+        repo do
+          `git submodule add #{submodule} sub &>/dev/null`
+          `git commit -m "Add submodule"`
+          `echo "Hello World" > sub/submodule-file`
+          `git submodule foreach 'git add submodule-file'`
+          `git submodule foreach 'git commit -m "Another commit"'`
+          `git add sub`
+          example.run
+        end
+      end
+
+      it 'keeps staged submodule change' do
+        subject
+        `git diff`.should be_empty
+        File.open('sub/submodule-file', 'r').read.should == "Hello World\n"
+      end
+    end
+
     context 'when a broken symlink is staged' do
       around do |example|
         repo do
@@ -162,6 +186,30 @@ describe Overcommit::HookContext::PreCommit do
       it 'deletes the file' do
         subject
         File.exist?('tracked-file').should == false
+      end
+    end
+
+    context 'when only a submodule change was staged' do
+      around do |example|
+        submodule = repo do
+          `git commit --allow-empty -m "Initial commit"`
+        end
+
+        repo do
+          `git submodule add #{submodule} sub &>/dev/null`
+          `git commit -m "Add submodule"`
+          `echo "Hello World" > sub/submodule-file`
+          `git submodule foreach 'git add submodule-file'`
+          `git submodule foreach 'git commit -m "Another commit"'`
+          `git add sub`
+          example.run
+        end
+      end
+
+      it 'keeps staged submodule change' do
+        subject
+        `git diff`.should be_empty
+        File.open('sub/submodule-file', 'r').read.should == "Hello World\n"
       end
     end
   end

--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -84,9 +84,9 @@ describe Overcommit::HookContext::PreCommit do
       end
 
       it 'keeps staged submodule change' do
-        subject
-        `git diff`.should be_empty
-        File.open('sub/submodule-file', 'r').read.should == "Hello World\n"
+        expect { subject }.to_not change {
+          (`git diff --cached` =~ /-Subproject commit[\s\S]*\+Subproject commit/).nil?
+        }.from(false)
       end
     end
 
@@ -207,9 +207,9 @@ describe Overcommit::HookContext::PreCommit do
       end
 
       it 'keeps staged submodule change' do
-        subject
-        `git diff`.should be_empty
-        File.open('sub/submodule-file', 'r').read.should == "Hello World\n"
+        expect { subject }.to_not change {
+          (`git diff --cached` =~ /-Subproject commit[\s\S]*\+Subproject commit/).nil?
+        }.from(false)
       end
     end
   end


### PR DESCRIPTION
Don't clear the working tree or apply the last stash if only submodule changes are staged.

Fixes #148