### PR TITLE
Change hook summary message to mention warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   and restore them on uninstall
 * Don't clear working tree after pre-commit hook when only submodule changes
   are present
+* Change hook summary message to mention warnings if there were any
 
 ## 0.23.0
 

--- a/lib/overcommit/hook_runner.rb
+++ b/lib/overcommit/hook_runner.rb
@@ -42,11 +42,13 @@ module Overcommit
 
         interrupted = false
         run_failed = false
+        run_warned = false
 
         @hooks.each do |hook|
           hook_status = run_hook(hook)
 
           run_failed = true if [:bad, :fail].include?(hook_status)
+          run_warned = true if hook_status == :warn
 
           if hook_status == :interrupt
             # Stop running any more hooks and assume a bad result
@@ -55,7 +57,7 @@ module Overcommit
           end
         end
 
-        print_results(run_failed, interrupted)
+        print_results(run_failed, run_warned, interrupted)
 
         !(run_failed || interrupted)
       else
@@ -64,11 +66,16 @@ module Overcommit
       end
     end
 
-    def print_results(failed, interrupted)
+    # @param failed [Boolean]
+    # @param warned [Boolean]
+    # @param interrupted [Boolean]
+    def print_results(failed, warned, interrupted)
       if interrupted
         @printer.run_interrupted
       elsif failed
         @printer.run_failed
+      elsif warned
+        @printer.run_warned
       else
         @printer.run_succeeded
       end

--- a/lib/overcommit/printer.rb
+++ b/lib/overcommit/printer.rb
@@ -58,6 +58,13 @@ module Overcommit
       log.newline
     end
 
+    # Executed when no hooks failed by the end of the run, but some warned.
+    def run_warned
+      log.newline
+      log.warning "⚠ All #{hook_script_name} hooks passed, but with warnings"
+      log.newline
+    end
+
     # Executed when no hooks failed by the end of the run.
     def run_succeeded
       log.newline


### PR DESCRIPTION
If any hook in a hook run reports a warning, the summary message should
mention there were warnings and be displayed in a different color.

Current message when warnings present:

> ✓ All pre-commit hooks passed

New message:

> ⚠ All pre-commit hooks passed, but with warnings

This helps situations where the warning messages might have scrolled off
screen if you have a large number of hooks installed.

Closes #137.

Change-Id: I795f044b6ec4f2d9cb555683d6825b51ae9ca25a